### PR TITLE
fix: keep SiReader loadable after plugin reload

### DIFF
--- a/scripts/foliate-custom-elements.ts
+++ b/scripts/foliate-custom-elements.ts
@@ -1,0 +1,49 @@
+import type { Plugin } from "vite"
+
+const definitions = [
+  {
+    file: "view.js",
+    tag: "foliate-view",
+    constructor: "View",
+  },
+  {
+    file: "fixed-layout.js",
+    tag: "foliate-fxl",
+    constructor: "FixedLayout",
+  },
+  {
+    file: "paginator.js",
+    tag: "foliate-paginator",
+    constructor: "Paginator",
+  },
+] as const
+
+export function guardFoliateCustomElementRegistration(code: string, id: string) {
+  const normalizedId = id.replace(/\\/g, "/").split("?")[0]
+  if (!normalizedId.includes("/foliate-js/"))
+    return null
+
+  const definition = definitions.find(({ file }) => normalizedId.endsWith(`/${file}`))
+  if (!definition)
+    return null
+
+  const original = `customElements.define('${definition.tag}', ${definition.constructor})`
+  const occurrences = code.split(original).length - 1
+  if (occurrences !== 1) {
+    throw new Error(`Expected one Foliate custom-element registration in ${id}, found ${occurrences}: ${original}`)
+  }
+
+  const guarded = `if (!customElements.get('${definition.tag}')) ${original}`
+  return code.replace(original, guarded)
+}
+
+export function foliateCustomElementsGuard(): Plugin {
+  return {
+    name: "foliate-custom-elements-guard",
+    enforce: "pre",
+    transform(code, id) {
+      const transformed = guardFoliateCustomElementRegistration(code, id)
+      return transformed === null ? null : { code: transformed, map: null }
+    },
+  }
+}

--- a/tests/foliate-custom-elements.test.ts
+++ b/tests/foliate-custom-elements.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { runInNewContext } from "node:vm"
+import { describe, expect, it } from "vitest"
+import { guardFoliateCustomElementRegistration } from "../scripts/foliate-custom-elements"
+
+const cases = [
+  ["view.js", "foliate-view", "View"],
+  ["fixed-layout.js", "foliate-fxl", "FixedLayout"],
+  ["paginator.js", "foliate-paginator", "Paginator"],
+] as const
+
+describe("guardFoliateCustomElementRegistration", () => {
+  it.each(cases)("makes %s registration idempotent", (file, tag, constructor) => {
+    const source = `customElements.define('${tag}', ${constructor})`
+    const result = guardFoliateCustomElementRegistration(source, `C:\\repo\\node_modules\\foliate-js\\${file}`)
+
+    expect(result).toBe(`if (!customElements.get('${tag}')) ${source}`)
+
+    const registry = new Map<string, unknown>()
+    const customElements = {
+      get: (name: string) => registry.get(name),
+      define: (name: string, value: unknown) => {
+        if (registry.has(name))
+          throw new DOMException(`Custom element ${name} already exists`, "NotSupportedError")
+        registry.set(name, value)
+      },
+    }
+    const elementConstructor = class {}
+    const context = {
+      customElements,
+      [constructor]: elementConstructor,
+    }
+
+    expect(() => {
+      runInNewContext(result!, context)
+      runInNewContext(result!, context)
+    }).not.toThrow()
+    expect(registry.get(tag)).toBe(elementConstructor)
+  })
+
+  it.each(cases)("transforms the pinned Foliate %s source", (file, tag) => {
+    const id = resolve("node_modules", "foliate-js", file)
+    const source = readFileSync(id, "utf8")
+    const result = guardFoliateCustomElementRegistration(source, id)
+
+    expect(result).toContain(`if (!customElements.get('${tag}'))`)
+  })
+
+  it("ignores files outside the Foliate dependency", () => {
+    expect(guardFoliateCustomElementRegistration("const value = 1", "C:/repo/src/index.ts")).toBeNull()
+  })
+
+  it("fails when the pinned Foliate source no longer has the expected registration", () => {
+    expect(() => guardFoliateCustomElementRegistration("export class View {}", "C:/repo/node_modules/foliate-js/view.js"))
+      .toThrow("Expected one Foliate custom-element registration")
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ import {
 } from "vite"
 import { viteStaticCopy } from "vite-plugin-static-copy"
 import zipPack from "vite-plugin-zip-pack"
+import { foliateCustomElementsGuard } from "./scripts/foliate-custom-elements"
 
 const pluginInfo = require("./plugin.json")
 const PRIVATE_SOURCES_ID = "@private-sources"
@@ -57,6 +58,7 @@ export default defineConfig(({
     },
 
     plugins: [
+      foliateCustomElementsGuard(),
       {
         name: "private-sources",
         enforce: "pre",


### PR DESCRIPTION
## Problem

SiReader can disappear from SiYuan's active plugin list after the plugin is reloaded without restarting the frontend. The plugin remains enabled in configuration, but its UI and functionality are unavailable until SiYuan is restarted.

## Root cause

The bundled Foliate modules register these custom elements unconditionally:

- `foliate-view`
- `foliate-fxl`
- `foliate-paginator`

SiYuan evaluates the plugin bundle again during plugin reload. The document's `CustomElementRegistry` survives plugin unload, so the second registration throws `NotSupportedError` and stops module evaluation before the new plugin instance finishes loading.

## Changes

- Add a Vite transform that makes the three Foliate registrations idempotent.
- Fail the build if the pinned Foliate source no longer contains exactly one expected registration.
- Add regression tests for Windows paths, repeat evaluation, the pinned Foliate source, unrelated modules, and dependency drift.

The transform stays local to `node_modules/foliate-js/{view,fixed-layout,paginator}.js`. It does not change SiReader runtime behavior on the first load.

## Validation

- `npm run test:run`: 8 tests passed.
- Focused ESLint check for the new build helper and tests: passed.
- `npm run build`: passed; 182 modules transformed and `package.zip` generated.
- Verified the production `dist/index.js` contains guarded registrations for all three Foliate tags.
- `git diff --check`: passed.

The repository-wide TypeScript check still reports existing errors outside this change, and the checked-in ESLint configuration references a source file that is absent from the public repository, so neither is reported as a clean repository-wide gate.

## Compatibility note

Custom-element definitions cannot be replaced in an existing document. This fix safely reuses the already registered Foliate constructors during a same-version plugin reload. A frontend restart can still be appropriate when upgrading to a release that changes the embedded Foliate implementation.
